### PR TITLE
searchRequest interface

### DIFF
--- a/gogrep_test.go
+++ b/gogrep_test.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sync"
 	"testing"
 )
 
 func TestFindResults(t *testing.T) {
+	queue := make(PriorityQueue, 0)
+	sortChannel := make(chan resultRow, 100)
+	var waitGroup sync.WaitGroup
 
-	searchParams := searchParameters{
+	s := searchRequest{
 		path:      "./test",
 		pattern:   regexp.MustCompile("vulture"),
 		parseJSON: true,
@@ -18,8 +22,11 @@ func TestFindResults(t *testing.T) {
 			requestID:  "",
 			practiceID: -1,
 		},
+		waitGroup:   &waitGroup,
+		pq:          &queue,
+		sortChannel: sortChannel,
 	}
-	results := findResults(searchParams)
+	results := s.findResults()
 
 	m := map[string]interface{}{"message": map[string]interface{}{
 		"asctime":     "2020-05-03 11:10:12,112",

--- a/gogrep_test.go
+++ b/gogrep_test.go
@@ -16,7 +16,7 @@ func TestFindResults(t *testing.T) {
 
 	s := searchRequest{
 		path:      "./test",
-		pattern:   regexp.MustCompile("vulture"),
+		pattern:   regexp.MustCompile("captain"),
 		parseJSON: true,
 		filterValues: filterObject{
 			requestID:  "",
@@ -29,11 +29,11 @@ func TestFindResults(t *testing.T) {
 	results := s.findResults()
 
 	m := map[string]interface{}{"message": map[string]interface{}{
-		"asctime":     "2020-05-03 11:10:12,112",
+		"asctime":     "2020-05-03 13:10:12,112",
 		"request_id":  "687449ef-4c93-863c-03a503a227fc",
 		"practice_id": 1204712973,
 		"user_id":     919888959,
-		"message":     "vulture",
+		"message":     "captain america",
 	}}
 	strM, _ := json.Marshal(m)
 	var exp [1]string

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"container/heap"
 	"encoding/json"
@@ -19,6 +20,41 @@ import (
 // an unfortunate hack to tolerate
 // unstructured JSON
 type jsonRow map[string]interface{}
+
+func (j jsonRow) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString("{")
+	length := len(j)
+	count := 0
+	for key, value := range j {
+		switch value.(type) {
+		case int:
+			buffer.WriteString(fmt.Sprintf("\"%s\":%d", key, value))
+			count++
+			if count < length {
+				buffer.WriteString(",")
+			}
+		case string:
+			buffer.WriteString(fmt.Sprintf("\"%s\":%s", key, value))
+			count++
+			if count < length {
+				buffer.WriteString(",")
+			}
+		default:
+			jsonified, err := json.Marshal(value)
+			if err != nil {
+				return nil, err
+			}
+			add := fmt.Sprintf("\"%s\":%s", key, jsonified)
+			buffer.WriteString(add)
+			count = count + len(add)
+			if count < length {
+				buffer.WriteString(",")
+			}
+		}
+	}
+	buffer.WriteString("}")
+	return buffer.Bytes(), nil
+}
 
 type resultRow struct {
 	stringContent string

--- a/main.go
+++ b/main.go
@@ -225,9 +225,15 @@ func (s *searchRequest) findResults() []string {
 	for s.pq.Len() > 0 {
 		item := heap.Pop(s.pq).(*Item)
 		value := item.value
-		jsonified, parseErr := json.Marshal(value)
-		if parseErr != nil {
-			log.Fatalf("Something went wrong. Error parsing JSON from heap.")
+		var jsonified []byte
+		if s.parseJSON {
+			var parseErr error
+			jsonified, parseErr = json.Marshal(value.jsonContent)
+			if parseErr != nil {
+				log.Fatalf("Something went wrong. Error parsing JSON from heap.")
+			}
+		} else {
+			jsonified = []byte(value.stringContent)
 		}
 		results = append(results, string(jsonified))
 	}

--- a/main.go
+++ b/main.go
@@ -338,29 +338,26 @@ func main() {
 	// either field will be filtered out.
 	filterValues := filterObject{}
 
-	if *practiceIDPtr != -1 {
-		filterValues.practiceID = *practiceIDPtr
-	}
-
-	if *requestIDPtr != "" {
-		filterValues.requestID = *requestIDPtr
-	}
+	filterValues.practiceID = *practiceIDPtr
+	filterValues.requestID = *requestIDPtr
 
 	queue := make(PriorityQueue, 0)
 	sortChannel := make(chan resultRow, 100)
 	var waitGroup sync.WaitGroup
 
 	s := searchRequest{
-		pattern:     pattern,
-		path:        *filenamePtr,
-		parseJSON:   *jsonPtr,
-		waitGroup:   &waitGroup,
-		sortChannel: sortChannel,
-		pq:          &queue}
+		pattern:      pattern,
+		path:         *filenamePtr,
+		parseJSON:    *jsonPtr,
+		filterValues: filterValues,
+		waitGroup:    &waitGroup,
+		sortChannel:  sortChannel,
+		pq:           &queue}
 
 	results := s.findResults()
-	encoder := json.NewEncoder(os.Stdout)
-	for row := range results {
-		encoder.Encode(row)
+	// encoder := json.NewEncoder(os.Stdout)
+	for _, row := range results {
+		// encoder.Encode(row)
+		fmt.Println(row)
 	}
 }


### PR DESCRIPTION
- Changes search interface to use `searchRequest` object and methods. This greatly reduces the amount of passed parameters needed in most functions.
- A custom JSON marshaller is introduced to stringify private and public fields alike.
- Test works all but nominally. Must check out deepEqual function.