### PR TITLE
Unexport priorityQueue and item types

### DIFF
--- a/searchrequest/pq.go
+++ b/searchrequest/pq.go
@@ -4,8 +4,8 @@ import (
 	"container/heap"
 )
 
-// An Item is something we manage in a priority queue.
-type Item struct {
+// An item is something we manage in a priority queue.
+type item struct {
 	value    ResultRow
 	priority string
 	// The index is needed by update and
@@ -13,32 +13,32 @@ type Item struct {
 	index int
 }
 
-// PriorityQueue list of pointers to item structs
-type PriorityQueue []*Item
+// priorityQueue list of pointers to item structs
+type priorityQueue []*item
 
-func (pq PriorityQueue) Len() int { return len(pq) }
+func (pq priorityQueue) Len() int { return len(pq) }
 
-func (pq PriorityQueue) Less(i, j int) bool {
+func (pq priorityQueue) Less(i, j int) bool {
 	isLess := pq[i].priority < pq[j].priority
 	return isLess
 }
 
-func (pq PriorityQueue) Swap(i, j int) {
+func (pq priorityQueue) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
 	pq[i].index = i
 	pq[j].index = j
 }
 
 // Push : pushes an item onto the priority queu
-func (pq *PriorityQueue) Push(x interface{}) {
+func (pq *priorityQueue) Push(x interface{}) {
 	n := len(*pq)
-	item := x.(*Item)
+	item := x.(*item)
 	item.index = n
 	*pq = append(*pq, item)
 }
 
 // Pop : removes an item from the priority queue
-func (pq *PriorityQueue) Pop() interface{} {
+func (pq *priorityQueue) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
@@ -48,8 +48,8 @@ func (pq *PriorityQueue) Pop() interface{} {
 	return item
 }
 
-// update modifies the priority and value of an Item in the queue.
-func (pq *PriorityQueue) update(item *Item, value ResultRow, priority string) {
+// update modifies the priority and value of an item in the queue.
+func (pq *priorityQueue) update(item *item, value ResultRow, priority string) {
 	item.value = value
 	item.priority = priority
 	heap.Fix(pq, item.index)

--- a/searchrequest/searchrequest.go
+++ b/searchrequest/searchrequest.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 )
 
+const ChannelSize = 100
+
 // an unfortunate hack to tolerate
 // unstructured JSON
 type jsonRow map[string]interface{}
@@ -247,7 +249,7 @@ func (s *SearchRequest) findMatches() filepath.WalkFunc {
 func (s *SearchRequest) FindResults() []string {
 
 	queue := make(priorityQueue, 0)
-	sortChannel := make(chan ResultRow, 100)
+	sortChannel := make(chan ResultRow, ChannelSize)
 	var waitGroup sync.WaitGroup
 
 	s.pq = &queue

--- a/searchrequest/searchrequest.go
+++ b/searchrequest/searchrequest.go
@@ -76,7 +76,7 @@ type SearchRequest struct {
 	FilterValues FilterObject
 	waitGroup    *sync.WaitGroup
 	sortChannel  chan ResultRow
-	pq           *PriorityQueue
+	pq           *priorityQueue
 }
 
 func PracticeIDMatches(row jsonRow, filter FilterObject) bool {
@@ -139,7 +139,7 @@ func (s *SearchRequest) mergeResults() {
 		} else {
 			priority = match.stringContent
 		}
-		item := &Item{
+		item := &item{
 			value:    match,
 			priority: priority,
 		}
@@ -246,7 +246,7 @@ func (s *SearchRequest) findMatches() filepath.WalkFunc {
 // FindResults returns results of executed query
 func (s *SearchRequest) FindResults() []string {
 
-	queue := make(PriorityQueue, 0)
+	queue := make(priorityQueue, 0)
 	sortChannel := make(chan ResultRow, 100)
 	var waitGroup sync.WaitGroup
 
@@ -275,7 +275,7 @@ func (s *SearchRequest) FindResults() []string {
 	results := []string{}
 
 	for s.pq.Len() > 0 {
-		item := heap.Pop(s.pq).(*Item)
+		item := heap.Pop(s.pq).(*item)
 		value := item.value
 		var jsonified []byte
 		if s.ParseJSON {


### PR DESCRIPTION
- Cleans up a few interface components to stay within searchrequest
- Constant variable for `sortChannel` capacity