### PR TITLE
Using goroutine worker pools instead of goroutine per file-line

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,12 +12,12 @@ import (
 
 func main() {
 	patternPtr := flag.String(
-		"p",
+		"e",
 		"",
 		"Pattern to search for. (required)")
 
 	filenamePtr := flag.String(
-		"d",
+		"f",
 		"./",
 		"File or directory to search in.")
 

--- a/searchrequest/searchrequest.go
+++ b/searchrequest/searchrequest.go
@@ -1,18 +1,14 @@
 package searchrequest
 
 import (
-	"bufio"
 	"bytes"
-	"compress/gzip"
 	"container/heap"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"sync"
 )
 
@@ -84,57 +80,6 @@ type SearchRequest struct {
 	pq           *priorityQueue
 }
 
-func PracticeIDMatches(row jsonRow, filter FilterObject) bool {
-	message := (row["message"]).(map[string]interface{})
-	PracticeID, _ := message["practice_id"]
-	rowPracticeID := int(PracticeID.(float64))
-	filterPresent := (filter.PracticeID != -1)
-	if filterPresent && filter.PracticeID != rowPracticeID {
-		return false
-	}
-	return true
-}
-
-func RequestIDMatches(row jsonRow, filter FilterObject) bool {
-	message := (row["message"]).(map[string]interface{})
-	RequestID, _ := message["request_id"]
-	filterPresent := (filter.RequestID != "")
-	if filterPresent && filter.RequestID != RequestID {
-		return false
-	}
-	return true
-}
-
-func rowMatchesFilters(row jsonRow, filter FilterObject) bool {
-	return PracticeIDMatches(row, filter) && RequestIDMatches(row, filter)
-}
-
-func (s *SearchRequest) filterRow(row ResultRow) {
-
-	if s.ParseJSON && !rowMatchesFilters(
-		row.jsonContent, s.FilterValues) {
-		s.waitGroup.Done()
-		return
-	}
-
-	var rowBytes []byte
-	var match []byte
-
-	if s.ParseJSON {
-		rowBytes, _ = json.Marshal(row.jsonContent)
-	} else {
-		rowBytes = []byte(row.stringContent)
-	}
-
-	match = s.Pattern.Find(rowBytes)
-	if match == nil {
-		s.waitGroup.Done()
-		return
-	}
-
-	s.sortChannel <- row
-}
-
 func (s *SearchRequest) mergeResults() {
 	for match := range s.sortChannel {
 		var priority string
@@ -153,82 +98,6 @@ func (s *SearchRequest) mergeResults() {
 	}
 }
 
-func (s *SearchRequest) iterLinesJSON(
-	filePath string,
-	reader *io.Reader) {
-
-	decoder := json.NewDecoder(*reader)
-	for decoder.More() {
-		var r jsonRow
-		err := decoder.Decode(&r)
-		if err != nil {
-			log.Fatalf("Could not parse %s", filePath)
-		}
-		s.waitGroup.Add(1)
-		row := ResultRow{
-			jsonContent:   r,
-			stringContent: "",
-		}
-		s.rowChannel <- row
-	}
-}
-
-func (s *SearchRequest) iterLinesPlain(
-	filePath string,
-	reader *io.Reader) {
-
-	scanner := bufio.NewScanner(*reader)
-	for scanner.Scan() {
-		line := scanner.Text()
-		row := ResultRow{
-			jsonContent:   make(map[string]interface{}),
-			stringContent: line,
-			IsJSON:        s.ParseJSON,
-		}
-		s.waitGroup.Add(1)
-		s.rowChannel <- row
-	}
-}
-
-func (s *SearchRequest) findMatchInFile(
-	filePath string) {
-
-	defer s.waitGroup.Done()
-
-	file, err := os.Open(filePath)
-	if err != nil {
-		log.Fatalf("Could not open file %s", filePath)
-	}
-	defer file.Close()
-
-	// detect if the file is a
-	// zlib compressed file and
-	// automatically decompress
-	var reader io.Reader
-	// TODO(nickhil) : change this to
-	// detect gzipping based on file contents
-	// rather than .gz extension
-	if strings.Contains(filePath, ".gz") {
-		reader, err = gzip.NewReader(file)
-		if err != nil {
-			log.Fatalf(
-				"Error unzipping file %s\n%s", filePath, err)
-		}
-	} else {
-		reader = file
-	}
-
-	if s.ParseJSON {
-		s.iterLinesJSON(
-			filePath,
-			&reader)
-	} else {
-		s.iterLinesPlain(
-			filePath,
-			&reader)
-	}
-}
-
 func (s *SearchRequest) findMatches() filepath.WalkFunc {
 	return func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -244,21 +113,15 @@ func (s *SearchRequest) findMatches() filepath.WalkFunc {
 		return nil
 	}
 }
-func (s *SearchRequest) fileWorker() {
-	for filePath := range s.fileChannel {
-		s.findMatchInFile(filePath)
-	}
-}
 
-func (s *SearchRequest) rowWorker() {
-	for row := range s.rowChannel {
-		s.filterRow(row)
-	}
-}
 func (s *SearchRequest) setupWorkers() {
+	// TODO(nickhil) : remove magic number
 	for i := 0; i < 100; i++ {
-		go s.fileWorker()
-		go s.rowWorker()
+		fworker := fileWorker{s}
+		lworker := rowWorker{s}
+
+		go fworker.run()
+		go lworker.run()
 	}
 }
 

--- a/searchrequest/searchrequest.go
+++ b/searchrequest/searchrequest.go
@@ -177,12 +177,10 @@ func (s *SearchRequest) iterLinesJSON(
 			log.Fatalf("Could not parse %s", filePath)
 		}
 		s.waitGroup.Add(1)
-		// fmt.Print(r)
 		row := ResultRow{
 			jsonContent:   r,
 			stringContent: "",
 		}
-		// channel send
 		s.rowChannel <- row
 	}
 }
@@ -200,7 +198,6 @@ func (s *SearchRequest) iterLinesPlain(
 			IsJSON:        s.ParseJSON,
 		}
 		s.waitGroup.Add(1)
-		// channel send
 		s.rowChannel <- row
 	}
 }
@@ -254,7 +251,6 @@ func (s *SearchRequest) findMatches() filepath.WalkFunc {
 			return nil
 		case mode.IsRegular():
 			s.waitGroup.Add(1)
-			// channel send
 			s.fileChannel <- filePath
 		}
 		return nil

--- a/searchrequest/searchrequest.go
+++ b/searchrequest/searchrequest.go
@@ -110,9 +110,7 @@ func (s *SearchRequest) setupWorkers() {
 	}
 }
 
-// FindResults returns results of executed query
-func (s *SearchRequest) FindResults() []ResultRow {
-
+func (s *SearchRequest) initialize() {
 	queue := make(priorityQueue, 0)
 	sortChannel := make(chan ResultRow, ChannelSize)
 	rowChannel := make(chan ResultRow, ChannelSize)
@@ -124,6 +122,12 @@ func (s *SearchRequest) FindResults() []ResultRow {
 	s.rowChannel = rowChannel
 	s.fileChannel = fileChannel
 	s.waitGroup = &waitGroup
+}
+
+// FindResults returns results of executed query
+func (s *SearchRequest) FindResults() []ResultRow {
+
+	s.initialize()
 
 	// rather tham a goroutine
 	// per line, we use channels

--- a/searchrequest/worker.go
+++ b/searchrequest/worker.go
@@ -39,6 +39,8 @@ func (w *fileWorker) iterLinesJSON(
 		row := ResultRow{
 			jsonContent:   r,
 			stringContent: "",
+			IsJSON:        w.ParseJSON,
+			FilePath:      filePath,
 		}
 		w.rowChannel <- row
 	}
@@ -55,6 +57,7 @@ func (w *fileWorker) iterLinesPlain(
 			jsonContent:   make(map[string]interface{}),
 			stringContent: line,
 			IsJSON:        w.ParseJSON,
+			FilePath:      filePath,
 		}
 		w.waitGroup.Add(1)
 		w.rowChannel <- row

--- a/searchrequest/worker.go
+++ b/searchrequest/worker.go
@@ -1,0 +1,162 @@
+package searchrequest
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+type worker interface {
+	run()
+}
+
+type fileWorker struct {
+	*SearchRequest
+}
+
+func (w *fileWorker) run() {
+	for filePath := range w.fileChannel {
+		w.findMatchInFile(filePath)
+	}
+}
+
+func (w *fileWorker) iterLinesJSON(
+	filePath string,
+	reader *io.Reader) {
+
+	decoder := json.NewDecoder(*reader)
+	for decoder.More() {
+		var r jsonRow
+		err := decoder.Decode(&r)
+		if err != nil {
+			log.Fatalf("Could not parse %s", filePath)
+		}
+		w.waitGroup.Add(1)
+		row := ResultRow{
+			jsonContent:   r,
+			stringContent: "",
+		}
+		w.rowChannel <- row
+	}
+}
+
+func (w *fileWorker) iterLinesPlain(
+	filePath string,
+	reader *io.Reader) {
+
+	scanner := bufio.NewScanner(*reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+		row := ResultRow{
+			jsonContent:   make(map[string]interface{}),
+			stringContent: line,
+			IsJSON:        w.ParseJSON,
+		}
+		w.waitGroup.Add(1)
+		w.rowChannel <- row
+	}
+}
+
+func (w *fileWorker) findMatchInFile(
+	filePath string) {
+
+	defer w.waitGroup.Done()
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		log.Fatalf("Could not open file %s", filePath)
+	}
+	defer file.Close()
+
+	// detect if the file is a
+	// zlib compressed file and
+	// automatically decompress
+	var reader io.Reader
+	// TODO(nickhil) : change this to
+	// detect gzipping based on file contents
+	// rather than .gz extension
+	if strings.Contains(filePath, ".gz") {
+		reader, err = gzip.NewReader(file)
+		if err != nil {
+			log.Fatalf(
+				"Error unzipping file %s\n%s", filePath, err)
+		}
+	} else {
+		reader = file
+	}
+
+	if w.ParseJSON {
+		w.iterLinesJSON(
+			filePath,
+			&reader)
+	} else {
+		w.iterLinesPlain(
+			filePath,
+			&reader)
+	}
+}
+
+type rowWorker struct {
+	*SearchRequest
+}
+
+func (w *rowWorker) run() {
+	for row := range w.rowChannel {
+		w.filterRow(row)
+	}
+}
+
+func practiceIDMatches(row jsonRow, filter FilterObject) bool {
+	message := (row["message"]).(map[string]interface{})
+	PracticeID, _ := message["practice_id"]
+	rowPracticeID := int(PracticeID.(float64))
+	filterPresent := (filter.PracticeID != -1)
+	if filterPresent && filter.PracticeID != rowPracticeID {
+		return false
+	}
+	return true
+}
+
+func requestIDMatches(row jsonRow, filter FilterObject) bool {
+	message := (row["message"]).(map[string]interface{})
+	RequestID, _ := message["request_id"]
+	filterPresent := (filter.RequestID != "")
+	if filterPresent && filter.RequestID != RequestID {
+		return false
+	}
+	return true
+}
+
+func rowMatchesFilters(row jsonRow, filter FilterObject) bool {
+	return practiceIDMatches(row, filter) && requestIDMatches(row, filter)
+}
+
+func (w *rowWorker) filterRow(row ResultRow) {
+
+	if w.ParseJSON && !rowMatchesFilters(
+		row.jsonContent, w.FilterValues) {
+		w.waitGroup.Done()
+		return
+	}
+
+	var rowBytes []byte
+	var match []byte
+
+	if w.ParseJSON {
+		rowBytes, _ = json.Marshal(row.jsonContent)
+	} else {
+		rowBytes = []byte(row.stringContent)
+	}
+
+	match = w.Pattern.Find(rowBytes)
+	if match == nil {
+		w.waitGroup.Done()
+		return
+	}
+
+	w.sortChannel <- row
+}

--- a/searchrequest/worker.go
+++ b/searchrequest/worker.go
@@ -165,7 +165,7 @@ type sortWorker struct {
 	*SearchRequest
 }
 
-func (w *sortWorker) mergeResults() {
+func (w *sortWorker) run() {
 	for match := range w.sortChannel {
 		var priority string
 		if w.ParseJSON {


### PR DESCRIPTION
- previous concurrency pattern used one goroutine per file and one goroutine per line in each file. Given the `2KB` stack space overhead of a goroutine, this doesn't seem practical for searching large codebases of ~25 million lines (e.g. linux kernel source tree, process memory would be 1TB).
- instead, we're now using two worker pools; `fileWorker` and `lineWorker` prototyped in `worker.go` 
- the sorting goroutine fits into this pattern as well, and is now realized as `sortWorker`.